### PR TITLE
Fix in sample implementation

### DIFF
--- a/lib/srfi/:241/match.sls
+++ b/lib/srfi/:241/match.sls
@@ -142,7 +142,8 @@
                     #`(if (pair? #,expr)
                           (let ([e1 (car #,expr)]
                                 [e2 (cdr #,expr)])
-                            #,(mat1 (lambda () (mat2 k))))))
+                            #,(mat1 (lambda () (mat2 k))))
+                          (fail)))
                   (append pvars1 pvars2) (append catas1 catas2))))]
             [unquote
              (ill-formed-match-pattern-violation)]

--- a/srfi-241.html
+++ b/srfi-241.html
@@ -129,6 +129,13 @@
       constants are not.
     </p>
 
+    <p>Note that in R<sup>6</sup>RS matching brackets may be used in
+      place of matching parentheses and vice versa, mostly for
+      readability.  We use brackets in this specification to document
+      a recommended style.  Users of Scheme systems not supporting
+      brackets (or users who don't like brackets) can replace them
+      with parentheses throughout.</p>
+
     <pre>    (match '(a 17 37)
       [(a ,x) 1]
       [(b ,x ,y) 2]

--- a/test-match.sps
+++ b/test-match.sps
@@ -205,6 +205,12 @@
 		      (split '(a b c d e f)))
 		  list)))
 
+;;; Extra tests
+
+(assert (match 'a
+          [(,x) #f]
+          [,_ #t]))
+
 ;; Local Variables:
 ;; mode: scheme
 ;; End:


### PR DESCRIPTION
This fixes a missing "else" clause in a macro-generated `if`.